### PR TITLE
Step4 - 블랙잭(리팩토링)

### DIFF
--- a/src/main/kotlin/domain/player/state/Started.kt
+++ b/src/main/kotlin/domain/player/state/Started.kt
@@ -4,16 +4,9 @@ import domain.card.CardState
 import domain.card.PlayingCard
 import domain.card.PlayingCards
 import exception.IllegalDrawException
-import exception.IllegalPlayerStateException
 import exception.IllegalStayException
 
 class Started(cards: PlayingCards) : Running(cards) {
-    init {
-        if (cards.size != PlayingCards.START_SIZE) {
-            throw IllegalPlayerStateException("게임을 시작하면 두 장의 카드를 지급받아야 합니다.")
-        }
-    }
-
     override fun stay(): PlayerState {
         throw IllegalStayException("시작할 때는 stay 할 수 없습니다.")
     }

--- a/src/test/kotlin/domain/player/DealerTest.kt
+++ b/src/test/kotlin/domain/player/DealerTest.kt
@@ -4,6 +4,7 @@ import domain.card.CardGenerator
 import domain.card.Denomination
 import domain.card.MockedCardGenerator
 import domain.card.PlayingCard
+import domain.card.PlayingCards
 import domain.card.Suit
 import exception.IllegalDrawException
 import org.assertj.core.api.Assertions.assertThat
@@ -34,20 +35,14 @@ internal class DealerTest {
     @Test
     fun drawable() {
         val expectedScore = 16
-        val dealerCards = mutableListOf(
+        val dealerCards = listOf(
             PlayingCard.of(Denomination.ACE, Suit.CLUBS),
             PlayingCard.of(Denomination.ACE, Suit.DIAMONDS),
             PlayingCard.of(Denomination.ACE, Suit.HEARTS),
             PlayingCard.of(Denomination.ACE, Suit.SPADES),
             PlayingCard.of(Denomination.TWO, Suit.CLUBS)
         )
-        val cardGenerator = object : CardGenerator {
-            override fun getCard(): PlayingCard = dealerCards.removeFirst()
-        }
-        val dealer = Dealer(cardGenerator)
-        while (dealerCards.isNotEmpty()) {
-            dealer.play(true, cardGenerator)
-        }
+        val dealer = Dealer(PlayingCards(dealerCards))
         assertAll(
             { assertThat(dealer.isDrawable()).isTrue },
             { assertThat(dealer.score()).isEqualTo(expectedScore) }
@@ -58,7 +53,7 @@ internal class DealerTest {
     @Test
     fun notDrawable() {
         val expectedScore = 18
-        val dealerCards = mutableListOf(
+        val dealerCards = listOf(
             PlayingCard.of(Denomination.ACE, Suit.CLUBS),
             PlayingCard.of(Denomination.ACE, Suit.DIAMONDS),
             PlayingCard.of(Denomination.ACE, Suit.HEARTS),
@@ -66,13 +61,7 @@ internal class DealerTest {
             PlayingCard.of(Denomination.TWO, Suit.CLUBS),
             PlayingCard.of(Denomination.TWO, Suit.DIAMONDS)
         )
-        val cardGenerator = object : CardGenerator {
-            override fun getCard(): PlayingCard = dealerCards.removeFirst()
-        }
-        val dealer = Dealer(cardGenerator)
-        while (dealerCards.isNotEmpty()) {
-            dealer.play(true, cardGenerator)
-        }
+        val dealer = Dealer(PlayingCards(dealerCards))
         assertAll(
             { assertThat(dealer.isDrawable()).isFalse },
             { assertThat(dealer.score()).isEqualTo(expectedScore) },

--- a/src/test/kotlin/domain/player/DealerTest.kt
+++ b/src/test/kotlin/domain/player/DealerTest.kt
@@ -1,7 +1,10 @@
 package domain.player
 
 import domain.card.CardGenerator
+import domain.card.Denomination
 import domain.card.MockedCardGenerator
+import domain.card.PlayingCard
+import domain.card.Suit
 import exception.IllegalDrawException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -9,8 +12,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
 
 internal class DealerTest {
     private lateinit var cardGenerator: CardGenerator
@@ -30,10 +31,23 @@ internal class DealerTest {
     }
 
     @DisplayName("Dealer 의 점수가 16점 이하이면, 딜러는 카드를 뽑을 수 있다.")
-    @ParameterizedTest
-    @CsvSource("1,13", "2,14", "3,16", "6,12", "7,15")
-    fun drawable(times: Int, expectedScore: Int) {
-        repeat(times) { dealer.play(true, cardGenerator) }
+    @Test
+    fun drawable() {
+        val expectedScore = 16
+        val dealerCards = mutableListOf(
+            PlayingCard.of(Denomination.ACE, Suit.CLUBS),
+            PlayingCard.of(Denomination.ACE, Suit.DIAMONDS),
+            PlayingCard.of(Denomination.ACE, Suit.HEARTS),
+            PlayingCard.of(Denomination.ACE, Suit.SPADES),
+            PlayingCard.of(Denomination.TWO, Suit.CLUBS)
+        )
+        val cardGenerator = object : CardGenerator {
+            override fun getCard(): PlayingCard = dealerCards.removeFirst()
+        }
+        val dealer = Dealer(cardGenerator)
+        while (dealerCards.isNotEmpty()) {
+            dealer.play(true, cardGenerator)
+        }
         assertAll(
             { assertThat(dealer.isDrawable()).isTrue },
             { assertThat(dealer.score()).isEqualTo(expectedScore) }
@@ -41,10 +55,24 @@ internal class DealerTest {
     }
 
     @DisplayName("Dealer 의 점수가 16점 초과이면, 딜러는 카드를 뽑을 수 없다.")
-    @ParameterizedTest
-    @CsvSource("4,18", "5,20", "8,18", "9,21")
-    fun notDrawable(times: Int, expectedScore: Int) {
-        repeat(times) { dealer.play(true, cardGenerator) }
+    @Test
+    fun notDrawable() {
+        val expectedScore = 18
+        val dealerCards = mutableListOf(
+            PlayingCard.of(Denomination.ACE, Suit.CLUBS),
+            PlayingCard.of(Denomination.ACE, Suit.DIAMONDS),
+            PlayingCard.of(Denomination.ACE, Suit.HEARTS),
+            PlayingCard.of(Denomination.ACE, Suit.SPADES),
+            PlayingCard.of(Denomination.TWO, Suit.CLUBS),
+            PlayingCard.of(Denomination.TWO, Suit.DIAMONDS)
+        )
+        val cardGenerator = object : CardGenerator {
+            override fun getCard(): PlayingCard = dealerCards.removeFirst()
+        }
+        val dealer = Dealer(cardGenerator)
+        while (dealerCards.isNotEmpty()) {
+            dealer.play(true, cardGenerator)
+        }
         assertAll(
             { assertThat(dealer.isDrawable()).isFalse },
             { assertThat(dealer.score()).isEqualTo(expectedScore) },

--- a/src/test/kotlin/domain/player/state/HitTest.kt
+++ b/src/test/kotlin/domain/player/state/HitTest.kt
@@ -42,7 +42,6 @@ internal class HitTest {
         assertThat(hit.score()).isEqualTo(expectedScore)
     }
 
-
     @DisplayName("Hit 에서 stay 하면 Stay 상태로 이동한다.")
     @Test
     fun stay() {

--- a/src/test/kotlin/domain/player/state/StartedTest.kt
+++ b/src/test/kotlin/domain/player/state/StartedTest.kt
@@ -1,13 +1,11 @@
 package domain.player.state
 
 import domain.card.Denomination
-import domain.card.MockedCardGenerator
 import domain.card.PlayingCard
 import domain.card.PlayingCards
 import domain.card.Suit
 import exception.IllegalDrawException
 import exception.IllegalEarningRate
-import exception.IllegalPlayerStateException
 import exception.IllegalStayException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -27,16 +25,6 @@ internal class StartedTest {
     @BeforeEach
     fun setUp() {
         started = Started(PlayingCards(cardList))
-    }
-
-    @DisplayName("시작할 때는 반드시 두 장의 카드를 받아야 한다.")
-    @ParameterizedTest
-    @ValueSource(ints = [1, 3, 4, 5, 6, 7])
-    fun constructor(size: Int) {
-        val cardGenerator = MockedCardGenerator()
-        val cards = PlayingCards((1..size).map { cardGenerator.getCard() })
-        assertThatExceptionOfType(IllegalPlayerStateException::class.java)
-            .isThrownBy { Started(cards) }
     }
 
     @DisplayName("Started 상태에서는 earningRate 를 알 수 없다.")


### PR DESCRIPTION
#149  애서 [피드백](https://github.com/next-step/kotlin-blackjack/pull/149#discussion_r753616805) 주신 내용을 반영했습니다.

반복문 제거를 요구하셨는데, 카드 뭉치인 PlayingCards를 직접 Dealer 에게 넣어주면,
반드시 처음 카드 뭉치는 2개의 카드만 받을 수 있다는 다른 비즈니스 로직에 걸렸습니다.

첫 draw 의 카드는 2장이어야 한다는 비즈니스 로직을 없앨까 하고 삽질을 하다가,
결국 해당 테스트에서 중요한 것은 반복문을 없애는 게 아니라,
테스트 코드를 읽는 다른 동료가, dealer 가 어떤 카드를 갖고 있는지 쉽게 알 수 있도록 해야한다는 점이라고 생각이 들었습니다.

그래서 해당 테스트에서 Dealer 가 어떤 카드를 갖고 있는지, cardGenerator 를 object 로 만들어서,
쉽게 알 수 있도록 하였습니다.

나름 며칠간 고민해서 테스트 코드를 고쳐보았는데, 의도와 부합하였으면 좋겠네요.
나름 꽤 진지하게 고민해볼만한 부분이었어서, 피드백 정말 감사합니다!
보통 프로덕트 코드에만 신경을 쓰지, 테스트 코드의 가독성은 신경을 덜 쓰게 되는데,
테스트 코드의 가독성 또한, 프로덕트 코드의 가독성 만큼 중요하다는 것을 꺠닫게 되었네요.